### PR TITLE
Spawning fixes: Min/max radius, node light check, spawn cap, biome check

### DIFF
--- a/mob_meta.lua
+++ b/mob_meta.lua
@@ -123,7 +123,7 @@ local mob = {
     damage = 2,
     speed = 4,
 	tracking_range = 16,
-    despawn_after = 100,
+    despawn_after = nil,
     -- Physics
     max_fall = 3,
 	stepheight = 1.1,

--- a/spawning.lua
+++ b/spawning.lua
@@ -78,6 +78,7 @@ function creatura.register_mob_spawn(name, def)
         biomes = def.biomes or nil,
         spawn_cluster = def.spawn_cluster or false,
         spawn_in_nodes = def.spawn_in_nodes or false,
+        spawn_cap = def.spawn_cap or 5,
         send_debug = def.send_debug or false
     }
     creatura.registered_mob_spawns[name] = spawn
@@ -146,6 +147,21 @@ function execute_spawns(player)
         or random(spawn.chance) > 1 then return end
         local max_radius = spawn.max_radius or max_spawn_radius
         local min_radius = spawn.min_radius or min_spawn_radius
+
+        -- Spawn cap check
+        local objects = minetest.get_objects_inside_radius(pos, max_radius)
+        local object_count = 0
+        for _, object in ipairs(objects) do
+            if creatura.is_alive(object)
+            and not object:is_player()
+            and object:get_luaentity().name == mob then
+                object_count = object_count + 1
+            end
+        end
+        if object_count >= spawn.spawn_cap then
+            return
+        end
+
         local spawn_pos_center = {
             x = pos.x + random(-max_radius, max_radius),
             y = pos.y,

--- a/spawning.lua
+++ b/spawning.lua
@@ -167,9 +167,11 @@ function execute_spawns(player)
             y = pos.y,
             z = pos.z + random(-max_radius, max_radius)
         }
-        if vector.distance(pos, spawn_pos_center) < min_radius then
+        local dist = vector.distance(pos, spawn_pos_center)
+        if dist < min_radius or dist > max_radius then
             return
         end
+
         local index_func
         if spawn.spawn_in_nodes then
             index_func = minetest.find_nodes_in_area

--- a/spawning.lua
+++ b/spawning.lua
@@ -131,9 +131,9 @@ end
 
 local spawn_queue = {}
 
-local min_spawn_radius = 16
+local min_spawn_radius = 32
 
-local max_spawn_radius = 64
+local max_spawn_radius = 128
 
 function execute_spawns(player)
     if not player:get_pos() then return end
@@ -167,10 +167,6 @@ function execute_spawns(player)
             y = pos.y,
             z = pos.z + random(-max_radius, max_radius)
         }
-        local dist = vector.distance(pos, spawn_pos_center)
-        if dist < min_radius or dist > max_radius then
-            return
-        end
 
         local index_func
         if spawn.spawn_in_nodes then
@@ -185,6 +181,10 @@ function execute_spawns(player)
         local spawn_y_array = index_func(vec_raise(spawn_pos_center, -max_radius), vec_raise(spawn_pos_center, max_radius), spawn_on)
         if spawn_y_array[1] then
             local spawn_pos = spawn_y_array[1]
+		        local dist = vector.distance(pos, spawn_pos)
+		        if dist < min_radius or dist > max_radius then
+		            return
+		        end
 
             if spawn_pos.y > spawn.max_height
             or spawn_pos.y < spawn.min_height then

--- a/spawning.lua
+++ b/spawning.lua
@@ -173,7 +173,11 @@ function execute_spawns(player)
                 return
             end
 
-            local light = minetest.get_node_light(vec_raise(spawn_pos, 1)) or 7
+            local light_pos = spawn_pos
+            if not spawn.spawn_in_nodes then
+              light_pos = vec_raise(spawn_pos, 1)
+            end
+            local light = minetest.get_node_light(light_pos) or 7
 
             if light > spawn.max_light
             or light < spawn.min_light then


### PR DESCRIPTION
0. Contains changes from previous spawn fixes PR which fixed the spawn radius and node light check.
1. When spawning, check the number of this mob within the max spawn radius. If it's equal or higher to the spawn cap property for this mob (default: 5) then don't spawn.
2. Increased min/max spawn radius to 32/128, and made max radius spherical.
3. When checking what mob types we can spawn, uses the spawn position to get the biome, not the player's position. Removed mob-specific min/max spawn radius.
4. despawn_after defaulted to 100, and this can't be overridden to make a mob never despawn. It now defaults to nil, disabling despawn.