### PR TITLE
api: default_vitals: Fix typo that led to early bailout

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -396,7 +396,7 @@ end
 function creatura.default_vitals(self)
 	local pos = self.stand_pos
 	local node = self.stand_node
-	if not pos or node then return end
+	if not pos or not node then return end
 
 	local max_fall = self.max_fall or 3
 	local in_liquid = self.in_liquid


### PR DESCRIPTION
If `stand_node` was present, the first guard in `default_vitals` bailed out.

This was seemingly unexpected and might be a relict from the refactoring in 59602c9. There, a `not` got seemingly lost (from line ~1260 in mob_meta.lua) and was not brought over properly to api.lua.

We fix the guard to bail out only if at least one of `stand_pos` or `stand_node` are missing. Noww, default_vitals actually does its work again.

Fixes ElCeejo/animalia#99
Fixes ElCeejo/animalia#100
Fixes ElCeejo/animalia#78